### PR TITLE
css tweak to fix ugly looking word wrap/highlight issue

### DIFF
--- a/src/components/document/citation/citation.scss
+++ b/src/components/document/citation/citation.scss
@@ -1,5 +1,6 @@
 .np-citation {
-  background-color: rgba(183, 175, 62, 0.3);
+  
+  background-color: rgba(3, 155, 229, 0.3);
   padding: 5px 10px;
   display: inline-block;
 

--- a/src/components/document/citation/citation.scss
+++ b/src/components/document/citation/citation.scss
@@ -1,6 +1,7 @@
 .np-citation {
-  background-color: rgba(234, 228, 145, .3);
-  padding: 5px;
+  background-color: rgba(183, 175, 62, 0.3);
+  padding: 5px 10px;
+  display: inline-block;
 
   h4 {
     margin: 0 0 10px;


### PR DESCRIPTION
Simple css tweak to fix the weird highlight on citations that word wrap. Mainly the APA flavor