### PR TITLE
Add help icon to formula edit

### DIFF
--- a/src/components/formula/edit.html
+++ b/src/components/formula/edit.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
-<h1 class="np-heading md-display-1">{{ 'Editing' | t }} <a ng-href="{{ id === '__new' ? resource.uiBase : href(id) }}">{{ title }}</a></h1>
+<h1 class="np-heading md-display-1">{{ 'Editing' | t }} <a ng-href="{{ id === '__new' ? resource.uiBase : href(id) }}">{{ title }}</a>
+  <a ng-if="help && help.uri" ng-href="{{ help.uri }}">
+    <md-button class="md-icon-button">
+    <md-icon md-menu-origin>help</md-icon>
+    <md-tooltip>{{ 'help' | t }}</md-tooltip>
+  </md-button></a>
+</h1>
 
 <npdc:bottom-sheet options="bottomSheetOptions" ng-show="document._rev"></npdc:bottom-sheet>
 <div ng-class="{ 'np-bottom-sheet-static': bottomSheetOptions.alwaysShow }">

--- a/src/components/formula/formulaDirective.js
+++ b/src/components/formula/formulaDirective.js
@@ -10,6 +10,11 @@ var formula = function($mdDialog, $location, $routeParams, $filter,
     controller: function($scope) {
       'ngInject';
 
+      if (npdcAppConfig.help) {
+        $scope.help = npdcAppConfig.help;
+      }
+
+
       let initBottomSheet = function() {
         $scope.bottomSheetOptions = {
           items: [],


### PR DESCRIPTION
To enable the help icon, simply provide the URI to the documentation in the app.run block:

```js
npdcApp.run(npdcAppConfig => {
  npdcAppConfig.help = { uri: "https://example.com/docs" };
});