### PR TITLE
File upload overhaul

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npdc-common",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "Common modules for NPDC apps",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/formula/directives/file/FileController.js
+++ b/src/components/formula/directives/file/FileController.js
@@ -1,0 +1,79 @@
+'use strict';
+
+function FormulaFileController($scope, $mdDialog, $http, $routeParams, NpolarApiSecurity, fileFunnelService) {
+  'ngInject';
+
+  let ctrl = this;
+
+  ctrl.field = $scope.field;
+
+  ctrl.isNew = (params=$routeParams) => {
+    return params.id === '__new';
+  };
+
+  ctrl.canUpload = (security = NpolarApiSecurity, options=fileFunnelService.getOptions(ctrl.field)) => {
+    return (false === ctrl.isNew() && security.isAuthorized('create', options.server));
+  };
+
+  ctrl.canDelete = (security = NpolarApiSecurity, options=fileFunnelService.getOptions(ctrl.field)) => {
+    return security.isAuthorized('delete', options.server);
+  };
+
+  $scope.files = [];
+  let options = fileFunnelService.getOptions($scope.field);
+  //console.log('field', $scope.field, fileFunnelService.getOptions(), options);
+
+  let mapFile = function(link_field) {
+    let file = Object.assign({},link_field.value);
+
+    if (typeof options.valueToFileMapper === "function") {
+      file = options.valueToFileMapper(file);
+    }
+
+    if (file) {
+      if (!file.filename || !file.url) {
+        throw "The hashi file mapper should be an object with keys filename, url, [file_size, icon, extras].";
+      }
+      file.extras = link_field.fields.filter(field => (options.fields || []).includes(field.id));
+    }
+    return file;
+  };
+
+  $scope.id = $routeParams.id;
+
+  $scope.field.values.forEach(value => {
+    let file = mapFile(value);
+    $scope.files.push(file);
+  });
+
+  $scope.isFile = function(value, index, array) {
+    return !!$scope.files[index];
+  };
+
+  ctrl.displayUploadDialog = (ev) => {
+    console.log('displayUploadDialog', ev);
+    fileFunnelService.showUpload(ev, $scope.field, options).then(files => {
+      if (files) {
+        files.forEach(file => {
+          let length = $scope.files.push(file);
+          file.extras = $scope.field.values[length - 1].fields.filter(field => (options.fields || []).includes(field.id));
+        });
+      }
+    });
+  };
+
+  $scope.removeFile = function(index) {
+    let file = $scope.field.itemRemove(index);
+    if (typeof options.valueToFileMapper === "function") {
+      file = options.valueToFileMapper(file.value);
+    }
+    $scope.files = $scope.files.filter(f => f.md5sum !== file.md5sum);
+    $http.delete(file.url);
+  };
+
+  $scope.nrFiles = function () {
+    return $scope.files.filter(f => !!f).length;
+  };
+}
+
+module.exports = FormulaFileController;

--- a/src/components/formula/directives/file/file.html
+++ b/src/components/formula/directives/file/file.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<fieldset ng-class="{ valid: field.valid, error: field.error }" ng-if="field.visible">
+<fieldset ng-class="{ valid: field.valid, error: field.error }" ng-if="field.visible" ng-controller="NpdcFormulaFileController as ctrl">
   <md-whiteframe class="md-whiteframe-z2 np-formula-file">
 
     <legend>
@@ -55,8 +55,16 @@
       </li>
     </ul>
     <div layout="column" layout-align="space-between end" class="np-formula-file-upload">
-      <md-button class="md-raised md-primary" ng-disabled="disableUpload" ng-click="showUpload($event);"><md-icon>backup</md-icon></md-button>
+      <md-button class="md-raised md-primary" ng-disabled="!ctrl.canUpload()" ng-click="displayUploadDialog($event);">
+        <md-icon>backup</md-icon>
+        <md-tooltip ng-if="ctrl.canUpload()">Upload files</md-tooltip>
+      </md-button>
+      <p ng-show="!ctrl.canUpload()">
+        <span ng-if="!ctrl.isNew()">You are currently not authorized to upload (are you logged in?)</span>
+        <span ng-if="ctrl.isNew()">Uploading is disabled: You need to save before you can upload any files</span>
+      </p>
     </div>
+
     <div npdc:formula-validation-message class="np-validation-message"></div>
   </md-whiteframe>
 </fieldset>

--- a/src/components/formula/directives/file/file.html
+++ b/src/components/formula/directives/file/file.html
@@ -34,7 +34,7 @@
                   <md-tooltip>{{ value.visible ? i18n.text.minimize.tooltip : i18n.text.maximize.tooltip }}</md-tooltip>
                 </a>
                 <md-menu>
-                  <md-button aria-label="{{ i18n.text.remove.label }}" class="md-icon-button remove" ng-click="$mdOpenMenu($event)">
+                  <md-button ng-show="ctrl.canDelete()" aria-label="{{ i18n.text.remove.label }}" class="md-icon-button remove" ng-click="$mdOpenMenu($event)">
                     <md-icon md-menu-origin>close</md-icon>
                     <md-tooltip>{{ i18n.text.remove.tooltip }}</md-tooltip>
                   </md-button>
@@ -55,7 +55,7 @@
       </li>
     </ul>
     <div layout="column" layout-align="space-between end" class="np-formula-file-upload">
-      <md-button class="md-raised md-primary" ng-disabled="!ctrl.canUpload()" ng-click="displayUploadDialog($event);">
+      <md-button ng-disabled="!ctrl.canUpload()" ng-click="ctrl.displayUploadDialog($event);" class="md-raised md-primary">
         <md-icon>backup</md-icon>
         <md-tooltip ng-if="ctrl.canUpload()">Upload files</md-tooltip>
       </md-button>

--- a/src/components/formula/directives/file/fileDirective.js
+++ b/src/components/formula/directives/file/fileDirective.js
@@ -1,82 +1,13 @@
 'use strict';
 
-let fileDirective = function($http, $routeParams, fileFunnelService) {
+function fileDirective() {
   'ngInject';
 
   return {
     template: require('./file.html'),
     scope: false,
-    controller($scope, $mdDialog) {
-      'ngInject';
-
-      // let file = {
-      //   content_type: "application/octet-stream",
-      //   file_size: 23713,
-      //   filename: "IE11 - Win7.vbox-prev",
-      //   id: "54a4ce4d-b0f5-f103-c7f1-309529ecf81c",
-      //   md5sum: "ad3b5deb59195f710ea2d4a36ba606c8",
-      //   modified: "2016-02-19T14:36:56Z",
-      //   status: 409,
-      //   url: "https://dbtest.data.npolar.no/dumpster/54a4ce4d-b0f5-f103-c7f1-309529ecf81c",
-      // };
-
-      $scope.files = [];
-      let options = fileFunnelService.getOptions($scope.field);
-      //console.log('field', $scope.field, fileFunnelService.getOptions(), options);
-
-      let mapFile = function(link_field) {
-        let file = Object.assign({},link_field.value);
-
-        if (typeof options.valueToFileMapper === "function") {
-          file = options.valueToFileMapper(file);
-        }
-
-        if (file) {
-          if (!file.filename || !file.url) {
-            throw "The hashi file mapper should be an object with keys filename, url, [file_size, icon, extras].";
-          }
-          file.extras = link_field.fields.filter(field => (options.fields || []).includes(field.id));
-        }
-        return file;
-      };
-
-      $scope.id = $routeParams.id;
-
-      $scope.field.values.forEach(value => {
-        let file = mapFile(value);
-        $scope.files.push(file);
-      });
-
-      $scope.isFile = function(value, index, array) {
-        return !!$scope.files[index];
-      };
-
-      $scope.disableUpload = ($scope.id === "__new");
-
-      $scope.showUpload = function(ev) {
-        fileFunnelService.showUpload(ev, $scope.field, options).then(files => {
-          if (files) {
-            files.forEach(file => {
-              let length = $scope.files.push(file);
-              file.extras = $scope.field.values[length - 1].fields.filter(field => (options.fields || []).includes(field.id));
-            });
-          }
-        });
-      };
-
-      $scope.removeFile = function(index) {
-        let file = $scope.field.itemRemove(index);
-        if (typeof options.valueToFileMapper === "function") {
-          file = options.valueToFileMapper(file.value);
-        }
-        $http.delete(file.url);
-      };
-
-      $scope.nrFiles = function () {
-        return $scope.files.filter(f => !!f).length;
-      };
-    }
+    controller: 'NpdcFormulaFileController'
   };
-};
+}
 
 module.exports = fileDirective;

--- a/src/components/formula/directives/index.js
+++ b/src/components/formula/directives/index.js
@@ -6,6 +6,7 @@ var common = angular.module('npdcCommon');
 common.service('formulaAutoCompleteService', require('./autocomplete/autocompleteSourceService'));
 common.directive('npdcFormulaAutocomplete', require('./autocomplete/autocompleteDirective'));
 
+common.controller('NpdcFormulaFileController', require('./file/FileController'));
 common.directive('npdcFormulaFile', require('./file/fileDirective'));
 
 common.directive('npdcFormulaPerson', require('./person/personDirective'));

--- a/src/components/search/results/SearchResultsController.js
+++ b/src/components/search/results/SearchResultsController.js
@@ -30,8 +30,8 @@ var SearchResultsController = function($scope, $filter, $location, $http, Npolar
     $location.path('/');
   };
 
-  ctrl.hasFilters = () => {
-    return Object.keys($location.search()).find(k => (/^filter[-]/).test(k));
+  ctrl.hasFilters = (param=$location.search()) => {
+    return Object.keys(param).find(k => (/^filter[-]/).test(k));
   };
 
   // @todo FIXME sort
@@ -74,7 +74,6 @@ var SearchResultsController = function($scope, $filter, $location, $http, Npolar
     if (options.avatar) {
       return valueFromPath(entry, options.avatar);
     }
-
     return entry.id.substr(0,3);
   };
 

--- a/src/config/npdc-applications.json
+++ b/src/config/npdc-applications.json
@@ -284,7 +284,7 @@
 		"category": "public",
 		"promote": true
 	}, {
-		"link": "/courses",
+		"link": "/course",
 		"name": [{
 			"@language": "en",
 			"@value": "Courses"


### PR DESCRIPTION
File upload needs to get simpler, more powerful, and without annoying quirks:

**Simpler**:
Get rid of 
```js
throw "The hashi file mapper should be an object with keys filename, url, [file_size, icon, extras].";`
```
More **powerful**:
Need to be able to update source document, not just the field the uploader is attached to.

**Quirks**:
* User should not be able to remove JSON metadata if not allowed to DELETE file
* Ditto for changing URI etc